### PR TITLE
Update misc_whitelist.hosts

### DIFF
--- a/data/whitelist.d/misc_whitelist.hosts
+++ b/data/whitelist.d/misc_whitelist.hosts
@@ -51,6 +51,7 @@
 127.0.0.1 offer.aliexpress.com
 127.0.0.1 players.brightcove.net
 127.0.0.1 players.brightcove.net.edgekey.net
+127.0.0.1 pubsub-global.pubnub.com
 127.0.0.1 r.orange.fr
 127.0.0.1 rapidgator.net
 127.0.0.1 rlog.9gag.com


### PR DESCRIPTION
seems that an online learning website depends on it to function properly