### PR TITLE
EXAMPLE using k3s kubernetes distribution

### DIFF
--- a/EXAMPLES/k3s/README.md
+++ b/EXAMPLES/k3s/README.md
@@ -2,7 +2,7 @@
 
 K3s is a very lightweight kubernetes distribution. We can use k3s to setup a single node kubernetes cluster, and then use this to host our adblock dns server. Learn more about k3s [here](https://k3s.io/).
 
-We will also make use of Keel. Keel will help us to automatically update the adblock dns when a new version is available.
+We will also make use of Keel. Keel will help us to automatically update the adblock dns when a new version is available. Learn more about keel [here](https://keel.sh/).
 
 # Setting up
 
@@ -43,8 +43,16 @@ systemctl restart k3s
 
 Keel will help auto update our adblock dns server. Apply the deployment.
 ```
+kubectl apply -f 'https://sunstone.dev/keel?namespace=keel'
+```
+
+If you want to see the admin dashboard of keel, use the following instead
+```
 kubectl apply -f 'https://sunstone.dev/keel?namespace=keel&username=admin&password=admin&tag=latest'
 ```
+
+The dashboard can be accessed at `http://[YOUR_SERVER_IP]:9300`
+
 
 # Run the adblock server
 

--- a/EXAMPLES/k3s/README.md
+++ b/EXAMPLES/k3s/README.md
@@ -46,9 +46,11 @@ Keel will help auto update our adblock dns server. Apply the deployment.
 kubectl apply -f 'https://sunstone.dev/keel?namespace=keel&username=admin&password=admin&tag=latest'
 ```
 
-## Install the adblock server
+# Run the adblock server
 
-Apply the deployment
+1. Before proceeding any further, open the `adblock.yaml` file, and inspect the ConfigMap section. Feel free to edit the values as you see fit.
+
+2. Apply the deployment
 ```
 kubectl apply -f adblock.yaml
 ```

--- a/EXAMPLES/k3s/README.md
+++ b/EXAMPLES/k3s/README.md
@@ -1,0 +1,54 @@
+# Running on k3s
+
+K3s is a very lightweight kubernetes distribution. We can use k3s to setup a single node kubernetes cluster, and then use this to host our adblock dns server. Learn more about k3s [here](https://k3s.io/).
+
+We will also make use of Keel. Keel will help us to automatically update the adblock dns when a new version is available.
+
+# Setting up
+
+## Disable Systemd-Resolved
+
+See [here](https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f)
+
+## Install k3s
+
+Install k3s on your node. See [here](https://rancher.com/docs/k3s/latest/en/quick-start/).
+```
+curl -sfL https://get.k3s.io | sh -
+```
+
+We need to allow for service ports outside of the normal range. Open the `k3s.service` file.
+
+```shell
+nano /etc/systemd/system/k3s.service
+```
+
+We need to add some arguments for the kube apiserver to allow for low service ports range.
+
+```
+# file: /etc/systemd/system/k3s.service
+...
+ExecStart=/usr/local/bin/k3s \
+    server \
+    '--kube-apiserver-arg' 'service-node-port-range=1-32767' \
+```
+
+Reload the systemd daemon and restart k3s.
+```
+systemctl daemon-reload
+systemctl restart k3s
+```
+
+## Install keel
+
+Keel will help auto update our adblock dns server. Apply the deployment.
+```
+kubectl apply -f 'https://sunstone.dev/keel?namespace=keel&username=admin&password=admin&tag=latest'
+```
+
+## Install the adblock server
+
+Apply the deployment
+```
+kubectl apply -f adblock.yaml
+```

--- a/EXAMPLES/k3s/README.md
+++ b/EXAMPLES/k3s/README.md
@@ -4,6 +4,20 @@ K3s is a very lightweight kubernetes distribution. We can use k3s to setup a sin
 
 We will also make use of Keel. Keel will help us to automatically update the adblock dns when a new version is available. Learn more about keel [here](https://keel.sh/).
 
+# Current Progress
+
+At the moment, I managed to get the pod and service to be up an running. the service binds on port 53 on the host, and the pod can auto-updates without down time. However, due to k3s limitation, the service only listens to `ipv4`, and cannot bind to `ipv6`. I haven't figured out how work around this limitation.
+
+Logs are also not yet working as I haven't figured out how to export logs in this environment.
+
+- [x] dns pod up and running
+- [x] dns update with no downtime
+- [x] dns binds to port 53 on host
+- [x] dns listens to ipv4
+- [] dns listens to ipv6
+- [] dns debug logs
+- [] dns receives actual client ip
+
 # Setting up
 
 ## Disable Systemd-Resolved

--- a/EXAMPLES/k3s/adblock.yaml
+++ b/EXAMPLES/k3s/adblock.yaml
@@ -29,6 +29,19 @@ spec:
     app: adblock-dns
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adblock-dns-env
+  namespace: adblock
+data:
+  FQDN: dns.localhost.localdomain
+  IPV4: "127.0.0.1"
+  IPv6: "::1"
+  FORWARDER_1: "8.8.8.8"
+  FORWARDER_2: "8.8.4.4"
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,13 +69,9 @@ spec:
         - name: adblock-dns
           image: ragibkl/adblock_dns:latest
           imagePullPolicy: Always
-          env:
-            - name: FQDN
-              value: dns.localhost.localdomain
-            - name: IPV4
-              value: "0.0.0.0"
-            - name: IPv6
-              value: "::"
+          envFrom:
+            - configMapRef:
+                name: adblock-dns-env
           ports:
             - containerPort: 53
           resources:

--- a/EXAMPLES/k3s/adblock.yaml
+++ b/EXAMPLES/k3s/adblock.yaml
@@ -86,7 +86,7 @@ spec:
                 - -timeout=2
                 - zedo.com
                 - "127.0.0.1"
-            failureThreshold: 30
+            failureThreshold: 60
             periodSeconds: 10
           livenessProbe:
             exec:

--- a/EXAMPLES/k3s/adblock.yaml
+++ b/EXAMPLES/k3s/adblock.yaml
@@ -40,8 +40,7 @@ metadata:
     keel.sh/trigger: poll
     keel.sh/match-tag: "true"
   annotations:
-    keel.sh/pollSchedule: "@every 1m"
-
+    keel.sh/pollSchedule: "@every 5m"
 spec:
   replicas: 1
   selector:
@@ -66,19 +65,36 @@ spec:
               value: "::"
           ports:
             - containerPort: 53
+          resources:
+            limits:
+              memory: 1750Mi
+            requests:
+              memory: 1500Mi
+          startupProbe:
+            exec:
+              command:
+                - nslookup
+                - -timeout=2
+                - zedo.com
+                - "127.0.0.1"
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             exec:
               command:
                 - nslookup
+                - -timeout=2
                 - zedo.com
                 - "127.0.0.1"
-            initialDelaySeconds: 30
+            initialDelaySeconds: 5
+            failureThreshold: 3
             periodSeconds: 5
           readinessProbe:
             exec:
               command:
                 - nslookup
+                - -timeout=2
                 - zedo.com
                 - "127.0.0.1"
-            initialDelaySeconds: 30
+            initialDelaySeconds: 5
             periodSeconds: 5

--- a/EXAMPLES/k3s/adblock.yaml
+++ b/EXAMPLES/k3s/adblock.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: adblock
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: adblock
+  name: adblock-dns-svc
+  labels:
+    app: adblock-dns-svc
+spec:
+  type: NodePort
+  ports:
+    - name: tcp53
+      port: 53
+      targetPort: 53
+      nodePort: 53
+      protocol: TCP
+    - name: udp53
+      port: 53
+      targetPort: 53
+      nodePort: 53
+      protocol: UDP
+  selector:
+    app: adblock-dns
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: adblock
+  name: adblock-dns
+  labels:
+    app: adblock-dns
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/match-tag: "true"
+  annotations:
+    keel.sh/pollSchedule: "@every 1m"
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: adblock-dns
+  template:
+    metadata:
+      name: adblock-dns
+      labels:
+        app: adblock-dns
+    spec:
+      containers:
+        - name: adblock-dns
+          image: ragibkl/adblock_dns:latest
+          imagePullPolicy: Always
+          env:
+            - name: FQDN
+              value: dns.localhost.localdomain
+            - name: IPV4
+              value: "0.0.0.0"
+            - name: IPv6
+              value: "::"
+          ports:
+            - containerPort: 53
+          livenessProbe:
+            exec:
+              command:
+                - nslookup
+                - zedo.com
+                - "127.0.0.1"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - nslookup
+                - zedo.com
+                - "127.0.0.1"
+            initialDelaySeconds: 30
+            periodSeconds: 5

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ If you see something similar to the above prompt it means that `systemd-resolved
 
 1. Disable and stop the systemd-resolved service:
 
+UPDATE: see [here](https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f) instead!!!
+
 ```shell
 sudo systemctl disable systemd-resolved
 sudo systemctl stop systemd-resolved

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ systemd-r 967 systemd-resolve   17u  IPv4  34554      0t0  TCP localhost:domain 
 
 If you see something similar to the above prompt it means that `systemd-resolved` is running and needs to be disabled. There are plenty of guides on the internet on how to do this for specific Linux distros. The following should work for `Ubuntu Server 20.04`.
 
-1. Disable and stop the systemd-resolved service:
+UPDATE: see [this guide](https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f) instead!!!
 
-UPDATE: see [here](https://medium.com/@niktrix/getting-rid-of-systemd-resolved-consuming-port-53-605f0234f32f) instead!!!
+1. Disable and stop the systemd-resolved service:
 
 ```shell
 sudo systemctl disable systemd-resolved


### PR DESCRIPTION
The basic idea is, I want to replace the use of `docker` and `docker-compose`, with a minimal kubernetes setup using k3s.

Kubernetes, and specifically k3s has the following advantages:
- no `docker` or `docker-compose` dependencies. This simplifies server setup. This also reduces memory footprint since we no longer need a `docker` daemon.
- simpler install process. Instead of having to configure both `docker` and `docker-compose`, k3s can be setup quickly with a single command
- Kubernetes has proper concepts of `Deployments` and `rollingUpdate` strategy, and container health checks. This allows kubernetes to monitor the state of the adblock container, force a restart on container malfunctions, and also perform rolling update with zero downtime.

I'm also looking to use `keel.sh`. This will watch our upstream adblock-dns docker image for new versions, and perform auto apply of the deployments. This allows me to push new images for for our adblock dns, and the servers would auto-update. Combined with zero-downtime update above, it allows for seamless update process.
This also allows me to trigger regular weekly image updates, to keep the adblock up to date as much as possible.

Successfully merging this and deploying to our servers will fix ~https://github.com/ragibkl/adblock-dns-server/issues/58~