### PR TITLE
Update misc_whitelist.txt

### DIFF
--- a/data/whitelist.d/misc_whitelist.txt
+++ b/data/whitelist.d/misc_whitelist.txt
@@ -52,6 +52,7 @@ msn.com
 mywot.com
 offer.aliexpress.com
 platform-lookaside.fbsbx.com
+platform.twitter.com
 players.brightcove.net
 players.brightcove.net.edgekey.net
 pubsub-global.pubnub.com

--- a/data/whitelist.d/misc_whitelist.txt
+++ b/data/whitelist.d/misc_whitelist.txt
@@ -20,6 +20,8 @@ cdn.yandex.net
 click.virt.s50.exacttarget.com
 cn.uptodown.com
 coronastatus.fr
+cs1-apr-8315.wac.edgecastcdn.net
+cs491.wac.edgecastcdn.net
 cs531.wpc.edgecastcdn.net
 deals.souq.com
 display.360totalsecurity.com


### PR DESCRIPTION
Note: I can't find it in any lists used by bancuh, but it is still blocked and shows up in logs and twitter embeds don't work, am I missing something? Edit: it seems like there is a bug (if indeed the entry is not in any blocklists), because there is another entry found in multiple lists  `platform.twitter.complayercdn.jivox.com` and it seems like bancuh just reads the first part instead of the full domain thus the issue happens

Edit 2: ok I think I found the problem, it's that spotify list again, blocks `cs1-apr-8315.wac.edgecastcdn.net` and `cs491.wac.edgecastcdn.net` which blocks `platform.twitter.com`

Also suggestion: see which list each entry is blocked by in logs, makes troubleshooting way easier, thanks