### PR TITLE
use internal bind dns to recursively resolve queries

### DIFF
--- a/EXAMPLES/default/docker-compose.yml
+++ b/EXAMPLES/default/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   dns:
-    image: ragibkl/bancuh-dns:pr-2
+    image: ragibkl/bancuh-dns
     restart: always
     privileged: true # For some reason, some distro needs this
     ports:
@@ -26,7 +26,7 @@ services:
     network_mode: host
     env_file: .env
     environment:
-      - BACKEND=127.0.0.1:1153
+      BACKEND: 127.0.0.1:1153
     volumes:
       - letsencrypt:/etc/letsencrypt
     logging:

--- a/EXAMPLES/default/docker-compose.yml
+++ b/EXAMPLES/default/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   dns:
-    image: ragibkl/bancuh-dns
+    image: ragibkl/bancuh-dns:pr-2
     restart: always
     privileged: true # For some reason, some distro needs this
     ports:

--- a/EXAMPLES/default/sample.env
+++ b/EXAMPLES/default/sample.env
@@ -1,4 +1,5 @@
 CONFIG_URL=https://raw.githubusercontent.com/ragibkl/adblock-dns-server/master/data/configuration.yaml
+#FORWARDERS=8.8.8.8,8.8.4.4
 TLS_DOMAIN=dns1.example.com
 TLS_EMAIL=user@example.com
 TLS_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ cd adblock-dns-server
     ```shell
     # file: EXAMPLES/default/.env
     CONFIG_URL=https://raw.githubusercontent.com/ragibkl/adblock-dns-server/master/data/configuration.yaml
+    #FORWARDERS=8.8.8.8,8.8.4.4
     TLS_ENABLED=false
     TLS_DOMAIN=dns1.example.com
     TLS_EMAIL=user@example.com
@@ -161,6 +162,12 @@ cd adblock-dns-server
     The ads blocklist is also refreshed and recompiled every hour automatically.
     The default value here points to the configuration file maintained in this repo.
     See section below on how to use a customized blocklist configuration.
+
+    **FORWARDERS** - this value specifies custom backend dns servers to use as forwarders.
+    By default, this value is empty and the server will use a built-in bind server to recursively resolve dns queries.
+    This is best for privacy but might use more memory.
+    If you would like to forward dns queries to other dns servers, uncomment and set this to your preferred values.
+    This will also turn off the internal bind server.
 
     **TLS_ENABLED** - if set to `true`, the server will also enable DoH and DoT dns protocols.
     This requires that `TLS_DOMAIN` and `TLS_EMAIL` to be set correctly


### PR DESCRIPTION
needs: https://github.com/ragibkl/bancuh-dns/pull/2

Basically uses a variant of bancuh-dns that includes a built-in bind instance, that is used to recursively resolve dns queries.
I think this is the better approach to https://github.com/ragibkl/adblock-dns-server/pull/199