### PR TITLE
youtube ad blocklist

### DIFF
--- a/data/configuration.yaml
+++ b/data/configuration.yaml
@@ -1,5 +1,9 @@
 blacklist:
   - format: hosts
+    path: https://ewpratten.github.io/youtube_ad_blocklist/hosts.ipv4.txt
+  - format: hosts
+    path: https://ewpratten.github.io/youtube_ad_blocklist/hosts.ipv6.txt
+  - format: hosts
     path: https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final-Dual.hosts
   - format: hosts
     path: https://raw.githubusercontent.com/r-a-y/mobile-hosts/master/EasyPrivacySpecific.txt


### PR DESCRIPTION
Added to jp-dns3 config.
```
CONFIG_URL=https://raw.githubusercontent.com/ragibkl/adblock-dns-server/youtube-ad-blocklist/data/configuration.yaml
```